### PR TITLE
Add Proxmox VE 9.1.2 support

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -6,11 +6,10 @@ This document tracks Proxmox component versions that this plugin has been tested
 
 | Component | Version | Date | Notes |
 |-----------|---------|------|-------|
-| Proxmox VE | 8.x | 2025-12-11 | Initial release |
-| pve-access-control | - | 2025-12-11 | Uses verify_ticket, assemble_ticket |
-| pve-manager | - | 2025-12-11 | Patches pveproxy service |
-| pve-http-server | - | 2025-12-11 | Overrides auth_handler |
-| proxmox-widget-toolkit | - | 2025-12-11 | Integrates with LoginWindow |
+| Proxmox VE | 9.1.2 | 2025-12-11 | pve-manager 9.1.2 |
+| libpve-access-control | 9.0.4 | 2025-12-11 | Uses verify_ticket, assemble_ticket |
+| libpve-http-server-perl | 6.0.5 | 2025-12-11 | Overrides auth_handler |
+| proxmox-widget-toolkit | 5.1.2 | 2025-12-11 | Integrates with LoginWindow |
 
 ## Upstream Repositories
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ WebAuthn passwordless login for Proxmox VE. Enables TouchID, Windows Hello, hard
 
 ## Requirements
 
-- Proxmox VE 8.0 or later
+- Proxmox VE 9.1.2 (see [COMPATIBILITY.md](COMPATIBILITY.md) for tested versions)
 - WebAuthn must be configured in Datacenter options
 - User must have a WebAuthn credential registered (via Two Factor settings)
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+pve-webauthn-login (2025.12.2) stable; urgency=medium
+
+  * Proxmox VE 9.1.2 support
+  * Add /access/vncticket endpoint to auth bypass list
+  * Use dynamic Perl path detection for cross-version compatibility
+
+ -- chall37 <chall37@users.noreply.github.com>  Thu, 11 Dec 2025 22:00:00 -0500
+
 pve-webauthn-login (2025.12.1) stable; urgency=medium
 
   * Initial release (Proxmox VE 8.4.14)

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/chall37/pve-webauthn-login
 
 Package: pve-webauthn-login
 Architecture: all
-Depends: ${misc:Depends}, proxmox-ve (= 8.4.14)
+Depends: ${misc:Depends}, proxmox-ve (= 9.1.2)
 Description: WebAuthn passwordless login for Proxmox VE
  Enables TouchID, security keys, and other WebAuthn/passkey authenticators
  as a standalone login method for Proxmox VE, bypassing password entry.

--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,8 @@
 #!/usr/bin/make -f
 
+# Get Perl sitelib path dynamically
+PERL_SITELIB := $(shell perl -MConfig -e 'print $$Config{sitelib}')
+
 %:
 	dh $@
 
@@ -8,7 +11,7 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	install -D -m 644 src/PVE/WebAuthnLogin.pm \
-		debian/pve-webauthn-login/usr/local/share/perl/5.36.0/PVE/WebAuthnLogin.pm
+		debian/pve-webauthn-login$(PERL_SITELIB)/PVE/WebAuthnLogin.pm
 	install -D -m 644 js/webauthn-login.js \
 		debian/pve-webauthn-login/usr/local/share/pve-webauthn-login/webauthn-login.js
 	install -D -m 755 bin/pveproxy-wrapper \

--- a/src/PVE/WebAuthnLogin.pm
+++ b/src/PVE/WebAuthnLogin.pm
@@ -49,6 +49,7 @@ BEGIN {
             || ($rel_uri eq '/access/webauthn-login' && $method eq 'POST')
             || ($rel_uri eq '/access/domains' && $method eq 'GET')
             || ($rel_uri eq '/access/ticket' && ($method eq 'GET' || $method eq 'POST'))
+            || ($rel_uri eq '/access/vncticket' && $method eq 'POST')
             || ($rel_uri eq '/access/openid/login' && $method eq 'POST')
             || ($rel_uri eq '/access/openid/auth-url' && $method eq 'POST')
         ) {


### PR DESCRIPTION
## Summary
- Add `/access/vncticket` endpoint to auth bypass list (required for PVE 9.x)
- Use dynamic Perl path detection for cross-version compatibility
- Change dependency to exact PVE version match (`= 9.1.2`)
- Remove Debian revision suffix from versioning
- Fix version history (2025.12.1 = PVE 8.4.14, 2025.12.2 = PVE 9.1.2)

## Test plan
- [x] Build package on PVE 9.1.2
- [x] Verify WebAuthn login flow works
- [x] Verify package fails to install on non-9.1.2 systems