### PR TITLE
Code review fixes for v2025.12.2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,12 +3,12 @@ Section: admin
 Priority: optional
 Maintainer: chall37 <chall37@users.noreply.github.com>
 Build-Depends: debhelper-compat (= 13)
-Standards-Version: 4.6.0
+Standards-Version: 4.7.2.0
 Homepage: https://github.com/chall37/pve-webauthn-login
 
 Package: pve-webauthn-login
 Architecture: all
-Depends: ${misc:Depends}, proxmox-ve (= 9.1.2)
+Depends: ${misc:Depends}, ${perl:Depends}, pve-manager (= 9.1.2)
 Description: WebAuthn passwordless login for Proxmox VE
  Enables TouchID, security keys, and other WebAuthn/passkey authenticators
  as a standalone login method for Proxmox VE, bypassing password entry.

--- a/debian/pve-webauthn-login.lintian-overrides
+++ b/debian/pve-webauthn-login.lintian-overrides
@@ -1,0 +1,8 @@
+# We intentionally install to /usr/local to survive Proxmox updates
+# This is a core design decision documented in the package description
+pve-webauthn-login: dir-in-usr-local [usr/local/share/*]
+pve-webauthn-login: file-in-usr-local [usr/local/share/*]
+pve-webauthn-login: file-in-unusual-dir [usr/local/share/*]
+
+# We restart PVE services directly (not our own units) after install/remove
+pve-webauthn-login: maintainer-script-calls-systemctl

--- a/js/webauthn-login.js
+++ b/js/webauthn-login.js
@@ -1,13 +1,13 @@
 // WebAuthn Passwordless Login for Proxmox VE
 // Adds a "Login with Passkey" button to the Proxmox login window
 
-(function() {
+(function init() {
     'use strict';
 
     // Wait for Ext to be ready
     if (typeof Ext === 'undefined') {
         console.log('WebAuthn Login: Ext not found, retrying...');
-        setTimeout(arguments.callee, 100);
+        setTimeout(init, 100);
         return;
     }
 

--- a/src/PVE/WebAuthnLogin.pm
+++ b/src/PVE/WebAuthnLogin.pm
@@ -157,7 +157,7 @@ sub patch_pveproxy {
 }
 
 #############################################
-# Part B: Register API endpoints
+# Part C: Register API endpoints
 #############################################
 
 # POST /api2/json/access/webauthn-challenge


### PR DESCRIPTION
## Summary
- Fix `arguments.callee` strict mode error in webauthn-login.js
- Update Standards-Version to 4.7.2.0
- Change dependency from `proxmox-ve` to `pve-manager` (correct package)
- Add `${perl:Depends}` to silence build warning
- Add lintian overrides for intentional /usr/local usage
- Fix comment typo in WebAuthnLogin.pm (Part B → Part C)

## Test plan
- [x] Built and tested on PVE 9.1.2
- [x] WebAuthn login flow verified working