### PR TITLE
Improve error message for passkey login without username

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+NOTES.md

--- a/js/webauthn-login.js
+++ b/js/webauthn-login.js
@@ -102,7 +102,7 @@
             }
 
             if (!username) {
-                Ext.Msg.alert(gettext('Error'), gettext('Please enter a username'));
+                Ext.Msg.alert(gettext('Error'), gettext('A username is required for Passkey logins.'));
                 return;
             }
 


### PR DESCRIPTION
Changes the error message from 'Please enter a username' to 'A username is required for Passkey logins.' for clarity.