### PR TITLE
Fix changelog: use CalVer, move changes under v2025.12.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and this project adheres to [Calendar Versioning](https://calver.org/) (YYYY.MM.micro).
 
 ## [Unreleased]
+
+## [2025.12.8] - 2025-12-12
 
 ### Added
 - Auto-update mechanism via daily systemd timer
@@ -42,4 +44,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Unknown users now return same error as disabled users (prevents enumeration)
 
-### Removed


### PR DESCRIPTION
- Changed versioning description from SemVer to CalVer (YYYY.MM.micro)
- Moved all changes from [Unreleased] to [2025.12.8]
- Removed empty sections