### PR TITLE
Add EOL (End of Life) workflow

### DIFF
--- a/bin/pvedaemon-wrapper
+++ b/bin/pvedaemon-wrapper
@@ -27,6 +27,12 @@ if ($@) {
     # Continue to run vanilla pvedaemon
 }
 
+# Check for EOL status and log warning
+my $eol_file = '/var/lib/pve-webauthn-login/eol.json';
+if (-f $eol_file) {
+    syslog('warning', "pve-webauthn-login: EOL - this module is no longer maintained. Uninstall with: apt remove pve-webauthn-login");
+}
+
 # Now load and run the real pvedaemon
 use PVE::Service::pvedaemon;
 

--- a/bin/pveproxy-wrapper
+++ b/bin/pveproxy-wrapper
@@ -27,6 +27,12 @@ if ($@) {
     # Continue to run vanilla pveproxy
 }
 
+# Check for EOL status and log warning
+my $eol_file = '/var/lib/pve-webauthn-login/eol.json';
+if (-f $eol_file) {
+    syslog('warning', "pve-webauthn-login: EOL - this module is no longer maintained. Uninstall with: apt remove pve-webauthn-login");
+}
+
 # Now load and run the real pveproxy
 use PVE::Service::pveproxy;
 

--- a/bin/update
+++ b/bin/update
@@ -17,12 +17,15 @@ REPO="chall37/pve-webauthn-login"
 KEY_PATH="/usr/local/share/pve-webauthn-login/keys/pve-webauthn-login.asc"
 EXPECTED_FINGERPRINT="D408D1D8A4B730F47EE17FE7FD3723E6F0A2ABD7"
 CACHE_DIR="/var/cache/pve-webauthn-login"
+STATE_DIR="/var/lib/pve-webauthn-login"
+EOL_FILE="$STATE_DIR/eol.json"
 
 TMP_DIR=$(mktemp -d)
 trap "rm -rf $TMP_DIR" EXIT
 
-# Ensure cache directory exists
+# Ensure directories exist
 mkdir -p "$CACHE_DIR"
+mkdir -p "$STATE_DIR"
 
 log() { logger -t pve-webauthn-login "$1"; }
 
@@ -72,6 +75,23 @@ if ! gpg --verify "$TMP_DIR/compatibility.json.asc" "$TMP_DIR/compatibility.json
     log "Update BLOCKED: compatibility.json signature verification failed"
     exit 1
 fi
+
+# Check for EOL status
+EOL_MESSAGE=$(grep -o '"eol"[[:space:]]*:[[:space:]]*{[^}]*}' "$TMP_DIR/compatibility.json" 2>/dev/null | \
+    grep -o '"message"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*:[[:space:]]*"\([^"]*\)".*/\1/' || true)
+
+if [ -n "$EOL_MESSAGE" ]; then
+    log "EOL: $EOL_MESSAGE"
+    # Write EOL status to file for UI to read
+    cat "$TMP_DIR/compatibility.json" | grep -o '"eol"[[:space:]]*:[[:space:]]*{[^}]*}' | \
+        sed 's/"eol"[[:space:]]*:[[:space:]]*//' > "$EOL_FILE" 2>/dev/null || \
+        echo '{"message":"This module has reached end-of-life."}' > "$EOL_FILE"
+    log "EOL status written to $EOL_FILE - please uninstall with: apt remove pve-webauthn-login"
+    exit 0
+fi
+
+# Clear EOL file if it exists but EOL is not set (in case of rollback)
+rm -f "$EOL_FILE" 2>/dev/null || true
 
 COMPAT_RELEASE=$(grep "\"$PVE_VERSION\"" "$TMP_DIR/compatibility.json" 2>/dev/null | sed 's/.*: *"\([^"]*\)".*/\1/')
 if [ -z "$COMPAT_RELEASE" ]; then

--- a/js/webauthn-login.js
+++ b/js/webauthn-login.js
@@ -14,6 +14,68 @@
     Ext.onReady(function() {
         console.log('WebAuthn Login: Ext ready, setting up...');
 
+        // EOL Banner - check for EOL status file and display warning if present
+        var checkAndShowEolBanner = function() {
+            // Check if banner already exists
+            if (Ext.get('pve-webauthn-eol-banner')) {
+                return;
+            }
+
+            // Check if user dismissed the banner this session
+            if (window.sessionStorage && window.sessionStorage.getItem('pve-webauthn-eol-dismissed')) {
+                return;
+            }
+
+            // Fetch EOL status file (only exists if EOL was detected by update script)
+            fetch('/webauthn-eol.json')
+                .then(function(response) {
+                    if (!response.ok) {
+                        // File doesn't exist = not EOL
+                        return null;
+                    }
+                    return response.json();
+                })
+                .then(function(eolData) {
+                    if (!eolData) {
+                        return;
+                    }
+
+                    var message = eolData.message || 'This module is no longer maintained.';
+
+                    Ext.DomHelper.insertFirst(document.body, {
+                        id: 'pve-webauthn-eol-banner',
+                        tag: 'div',
+                        style: 'position: fixed; top: 0; left: 0; right: 0; z-index: 100000; ' +
+                               'background: linear-gradient(135deg, #d32f2f 0%, #b71c1c 100%); ' +
+                               'color: white; padding: 12px 20px; text-align: center; ' +
+                               'font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; ' +
+                               'font-size: 14px; box-shadow: 0 2px 8px rgba(0,0,0,0.3);',
+                        html: '<span style="margin-right: 15px;">' +
+                              '<strong>pve-webauthn-login has reached end-of-life.</strong> ' +
+                              Ext.htmlEncode(message) + ' To uninstall: ' +
+                              '<code style="background: rgba(255,255,255,0.2); padding: 2px 8px; border-radius: 3px; font-family: monospace;">apt remove pve-webauthn-login</code>' +
+                              '</span>' +
+                              '<button id="pve-webauthn-eol-dismiss" style="background: rgba(255,255,255,0.2); border: 1px solid rgba(255,255,255,0.4); ' +
+                              'color: white; padding: 4px 12px; border-radius: 3px; cursor: pointer; font-size: 12px;">Dismiss</button>'
+                    });
+
+                    // Add dismiss handler
+                    Ext.get('pve-webauthn-eol-dismiss').on('click', function() {
+                        Ext.get('pve-webauthn-eol-banner').remove();
+                        // Remember dismissal for this session
+                        if (window.sessionStorage) {
+                            window.sessionStorage.setItem('pve-webauthn-eol-dismissed', 'true');
+                        }
+                    });
+                })
+                .catch(function() {
+                    // Silently ignore fetch errors (file doesn't exist = not EOL)
+                });
+        };
+
+        // Check for EOL status
+        checkAndShowEolBanner();
+
         // Function to add button to an existing login window
         var addButtonToWindow = function(loginWindow) {
             // Find the login button

--- a/src/PVE/WebAuthnLogin.pm
+++ b/src/PVE/WebAuthnLogin.pm
@@ -14,6 +14,9 @@ use PVE::API2::AccessControl;
 # Path to our custom JS file
 my $webauthn_js_path = '/usr/local/share/pve-webauthn-login/webauthn-login.js';
 
+# Path to EOL status file (written by update script when EOL detected)
+my $eol_file_path = '/var/lib/pve-webauthn-login/eol.json';
+
 # Track which parts loaded successfully
 our $auth_handler_patched = 0;
 our $api_endpoints_registered = 0;
@@ -140,6 +143,13 @@ sub patch_pveproxy {
             if (-f $webauthn_js_path) {
                 $self->{server_config}->{pages}->{'/webauthn-login.js'} = {
                     file => $webauthn_js_path,
+                };
+            }
+
+            # Add EOL status file if it exists (served without auth)
+            if (-f $eol_file_path) {
+                $self->{server_config}->{pages}->{'/webauthn-eol.json'} = {
+                    file => $eol_file_path,
                 };
             }
         };


### PR DESCRIPTION
## Summary

Adds infrastructure to notify users when the module reaches end-of-life, advising them to uninstall while keeping the module functional until manually removed.

## Changes

- **bin/update**: Detects `eol` field in compatibility.json, writes status to `/var/lib/pve-webauthn-login/eol.json`
- **src/PVE/WebAuthnLogin.pm**: Serves `/webauthn-eol.json` when EOL file exists
- **js/webauthn-login.js**: Fetches EOL status, shows dismissible warning banner (session-persistent dismiss)
- **bin/pveproxy-wrapper**: Logs EOL warning to syslog on service start
- **bin/pvedaemon-wrapper**: Logs EOL warning to syslog on service start

## To trigger EOL

Add to compatibility.json:
```json
{
  "eol": {"message": "This module is no longer maintained."},
  "9.1.2": "v2025.12.8"
}
```

## Tested

- EOL file creation and serving ✓
- Banner display and dismissal ✓
- Syslog warning on service start ✓